### PR TITLE
Compatibility with JDK 1.7

### DIFF
--- a/src/main/java/se/bjurr/prnfs/listener/UrlInvoker.java
+++ b/src/main/java/se/bjurr/prnfs/listener/UrlInvoker.java
@@ -9,7 +9,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.Base64;
+
+import javax.xml.bind.DatatypeConverter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,7 +29,7 @@ public class UrlInvoker {
    final URLConnection uc = url.openConnection();
    if (user.isPresent() && password.isPresent()) {
     final String userpass = user.get() + ":" + password.get();
-    final String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userpass.getBytes()));
+    final String basicAuth = "Basic " + new String(DatatypeConverter.printBase64Binary(userpass.getBytes("UTF-8")));
     uc.setRequestProperty("Authorization", basicAuth);
    }
    ir = new InputStreamReader(uc.getInputStream(), UTF_8);


### PR DESCRIPTION
If you ever consider backward compatibility to be relevant.

java.util.Base64 is available since 1.8 and javax.xml.bind.DatatypeConverter since 1.6.